### PR TITLE
Feat user types

### DIFF
--- a/YouTravel/Agent/AgentMainWindow.xaml
+++ b/YouTravel/Agent/AgentMainWindow.xaml
@@ -27,9 +27,9 @@
         <KeyBinding Modifiers="Ctrl" Key="R" Command="{Binding CmdViewReports, UpdateSourceTrigger=PropertyChanged}"/>
         <KeyBinding Modifiers="Ctrl" Key="T" Command="{Binding CmdToggleToolbar, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <KeyBinding Modifiers="Ctrl" Key="F1" Command="{Binding CmdLogin, UpdateSourceTrigger=PropertyChanged}"/>
-        <KeyBinding Modifiers="Ctrl" Key="F4" Command="{Binding CmdLogout, UpdateSourceTrigger=PropertyChanged}"/>
-        <KeyBinding Modifiers="Ctrl" Key="F2" Command="{Binding CmdRegister, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Key="F2" Command="{Binding CmdLogin, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Key="F4" Command="{Binding CmdLogout, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Key="F3" Command="{Binding CmdRegister, UpdateSourceTrigger=PropertyChanged}"/>
     </Window.InputBindings>
 
     <Window.Resources>
@@ -73,9 +73,9 @@
                         </MenuItem>
                     </MenuItem>
                     <Separator x:Name="menu_item_login_separator"/>
-                    <MenuItem x:Name="menu_item_login" Header="Login" Click="On_Login" InputGestureText="Ctrl+F1"></MenuItem>
-                    <MenuItem x:Name="menu_item_logout" Header="Logout" Click ="On_Logout" InputGestureText="Ctrl+F4"></MenuItem>
-                    <MenuItem x:Name="menu_item_register" Header="Register" Click ="On_Register" InputGestureText="Ctrl+F2" Template="{DynamicResource FinalSubMenuItemTemplate}"/>
+                    <MenuItem x:Name="menu_item_login" Header="Login" Click="On_Login" InputGestureText="F2"></MenuItem>
+                    <MenuItem x:Name="menu_item_logout" Header="Logout" Click ="On_Logout" InputGestureText="F4"></MenuItem>
+                    <MenuItem x:Name="menu_item_register" Header="Register" Click ="On_Register" InputGestureText="F3" Template="{DynamicResource FinalSubMenuItemTemplate}"/>
                     <Separator/>
                     <MenuItem Header="Exit" Click="ExitApp_Click" InputGestureText="Alt+F4" Template="{DynamicResource FinalSubMenuItemTemplate}"></MenuItem>
                 </MenuItem>

--- a/YouTravel/Agent/AgentMainWindow.xaml
+++ b/YouTravel/Agent/AgentMainWindow.xaml
@@ -56,7 +56,7 @@
         <StackPanel Grid.Row="0">
             <Menu>
                 <MenuItem Header="_File">
-                    <MenuItem Header="New" Template="{DynamicResource MenuItemTemplate}">
+                    <MenuItem x:Name="menu_item_new" Header="New" Template="{DynamicResource MenuItemTemplate}">
                         <MenuItem Header="Arrangement" Click="On_AddArrangement" InputGestureText="Ctrl+N" Template="{DynamicResource FinalSubMenuItemTemplate}">
                             <MenuItem.Icon>
                                 <Image Source="{StaticResource IcoAddArrangement}"/>
@@ -68,22 +68,22 @@
                             </MenuItem.Icon>
                         </MenuItem>
                     </MenuItem>
-                    <Separator/>
+                    <Separator x:Name="menu_item_logout_separator"/>
                     <MenuItem Header="Logout" Template="{DynamicResource FinalSubMenuItemTemplate}"></MenuItem>
                     <MenuItem Header="Exit" Click="ExitApp_Click" InputGestureText="Alt+F4" Template="{DynamicResource FinalSubMenuItemTemplate}"></MenuItem>
                 </MenuItem>
                 <MenuItem Header="_View">
-                    <MenuItem Header="Arrangements" Click="On_OpenArrangementList" InputGestureText="Ctrl+A" Template="{DynamicResource FinalSubMenuItemTemplate}">
+                    <MenuItem x:Name="menu_item_view_arrangements" Header="Arrangements" Click="On_OpenArrangementList" InputGestureText="Ctrl+A" Template="{DynamicResource FinalSubMenuItemTemplate}">
                         <MenuItem.Icon>
                             <Image Source="{StaticResource IcoArrangement}"/>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Places" Click="On_OpenPlaceList" InputGestureText="Ctrl+P" Template="{DynamicResource FinalSubMenuItemTemplate}">
+                    <MenuItem x:Name="menu_item_view_places" Header="Places" Click="On_OpenPlaceList" InputGestureText="Ctrl+P" Template="{DynamicResource FinalSubMenuItemTemplate}">
                         <MenuItem.Icon>
                             <Image Source="{StaticResource IcoPlace}"/>
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Monthly Reports" Click="On_MonthlyReports" InputGestureText="Ctrl+R" Template="{DynamicResource FinalSubMenuItemTemplate}">
+                    <MenuItem x:Name="menu_item_view_reports" Header="Monthly Reports" Click="On_MonthlyReports" InputGestureText="Ctrl+R" Template="{DynamicResource FinalSubMenuItemTemplate}">
                         <MenuItem.Icon>
                             <Image Source="{StaticResource IcoReport}"/>
                         </MenuItem.Icon>
@@ -121,7 +121,7 @@
                     </Style>
                 </ToolBarTray.Style>
 
-                <ToolBar Template="{StaticResource ToolBarTemplate1}" ItemsSource="{Binding ToolbarBtn_Nav}">
+                <ToolBar x:Name="toolbar_navigation" Template="{StaticResource ToolBarTemplate1}" ItemsSource="{Binding ToolbarBtn_Nav}">
                     <ToolBar.Style>
                         <Style TargetType="{x:Type ToolBar}" BasedOn="{StaticResource {x:Type ToolBar}}">
                             <Setter Property="Visibility" Value="Visible"/>
@@ -134,7 +134,7 @@
                     </ToolBar.Style>
                 </ToolBar>
 
-                <ToolBar Template="{StaticResource ToolBarTemplate1}" ItemsSource="{Binding ToolbarBtn_Arrangement}">
+                <ToolBar x:Name="toolbar_arrangement" Template="{StaticResource ToolBarTemplate1}" ItemsSource="{Binding ToolbarBtn_Arrangement}">
                     <ToolBar.Style>
                         <Style TargetType="{x:Type ToolBar}" BasedOn="{StaticResource {x:Type ToolBar}}">
                             <Setter Property="Visibility" Value="Visible"/>
@@ -147,7 +147,7 @@
                     </ToolBar.Style>
                 </ToolBar>
 
-                <ToolBar Template="{StaticResource ToolBarTemplate1}" ItemsSource="{Binding ToolbarBtn_Place}">
+                <ToolBar x:Name="toolbar_place" Template="{StaticResource ToolBarTemplate1}" ItemsSource="{Binding ToolbarBtn_Place}">
                     <ToolBar.Style>
                         <Style TargetType="{x:Type ToolBar}" BasedOn="{StaticResource {x:Type ToolBar}}">
                             <Setter Property="Visibility" Value="Visible"/>

--- a/YouTravel/Agent/AgentMainWindow.xaml
+++ b/YouTravel/Agent/AgentMainWindow.xaml
@@ -16,16 +16,19 @@
     </Window.CommandBindings>
 
     <Window.InputBindings>
-        <KeyBinding Modifiers="Ctrl" Key="Left" Command="{Binding CmdNavigateBack}"/>
-        <KeyBinding Modifiers="Ctrl" Key="Right" Command="{Binding CmdNavigateForward}"/>
+        <KeyBinding Modifiers="Ctrl" Key="Left" Command="{Binding CmdNavigateBack, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Modifiers="Ctrl" Key="Right" Command="{Binding CmdNavigateForward, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <KeyBinding Modifiers="Ctrl" Key="N" Command="{Binding CmdNewArrangement}"/>
-        <KeyBinding Modifiers="Ctrl" Key="A" Command="{Binding CmdViewArrangements}"/>
+        <KeyBinding Modifiers="Ctrl" Key="N" Command="{Binding CmdNewArrangement, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Modifiers="Ctrl" Key="A" Command="{Binding CmdViewArrangements, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <KeyBinding Modifiers="Ctrl+Shift" Key="N" Command="{Binding CmdNewPlace}"/>
-        <KeyBinding Modifiers="Ctrl" Key="P" Command="{Binding CmdViewPlaces}"/>
-        <KeyBinding Modifiers="Ctrl" Key="R" Command="{Binding CmdViewReports}"/>
-        <KeyBinding Modifiers="Ctrl" Key="T" Command="{Binding CmdToggleToolbar}"/>
+        <KeyBinding Modifiers="Ctrl+Shift" Key="N" Command="{Binding CmdNewPlace, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Modifiers="Ctrl" Key="P" Command="{Binding CmdViewPlaces, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Modifiers="Ctrl" Key="R" Command="{Binding CmdViewReports, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Modifiers="Ctrl" Key="T" Command="{Binding CmdToggleToolbar, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <KeyBinding Modifiers="Ctrl" Key="F1" Command="{Binding CmdLogin, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Modifiers="Ctrl" Key="F4" Command="{Binding CmdLogout, UpdateSourceTrigger=PropertyChanged}"/>
     </Window.InputBindings>
 
     <Window.Resources>
@@ -62,14 +65,16 @@
                                 <Image Source="{StaticResource IcoAddArrangement}"/>
                             </MenuItem.Icon>
                         </MenuItem>
-                        <MenuItem Header="Place" Click="On_AddPlace" InputGestureText="Ctrl+Shift+T" Template="{DynamicResource FinalSubMenuItemTemplate}">
+                        <MenuItem Header="Place" Click="On_AddPlace" InputGestureText="Ctrl+T" Template="{DynamicResource FinalSubMenuItemTemplate}">
                             <MenuItem.Icon>
                                 <Image Source="{StaticResource IcoAddPlace}"/>
                             </MenuItem.Icon>
                         </MenuItem>
                     </MenuItem>
-                    <Separator x:Name="menu_item_logout_separator"/>
-                    <MenuItem Header="Logout" Template="{DynamicResource FinalSubMenuItemTemplate}"></MenuItem>
+                    <Separator x:Name="menu_item_login_separator"/>
+                    <MenuItem x:Name="menu_item_login" Header="Login" Click="On_Login" InputGestureText="Ctrl+F1"></MenuItem>
+                    <MenuItem x:Name="menu_item_logout" Header="Logout" Click ="On_Logout" InputGestureText="Ctrl+F4" Template="{DynamicResource FinalSubMenuItemTemplate}"></MenuItem>
+                    <Separator/>
                     <MenuItem Header="Exit" Click="ExitApp_Click" InputGestureText="Alt+F4" Template="{DynamicResource FinalSubMenuItemTemplate}"></MenuItem>
                 </MenuItem>
                 <MenuItem Header="_View">

--- a/YouTravel/Agent/AgentMainWindow.xaml
+++ b/YouTravel/Agent/AgentMainWindow.xaml
@@ -29,6 +29,7 @@
 
         <KeyBinding Modifiers="Ctrl" Key="F1" Command="{Binding CmdLogin, UpdateSourceTrigger=PropertyChanged}"/>
         <KeyBinding Modifiers="Ctrl" Key="F4" Command="{Binding CmdLogout, UpdateSourceTrigger=PropertyChanged}"/>
+        <KeyBinding Modifiers="Ctrl" Key="F2" Command="{Binding CmdRegister, UpdateSourceTrigger=PropertyChanged}"/>
     </Window.InputBindings>
 
     <Window.Resources>
@@ -73,7 +74,8 @@
                     </MenuItem>
                     <Separator x:Name="menu_item_login_separator"/>
                     <MenuItem x:Name="menu_item_login" Header="Login" Click="On_Login" InputGestureText="Ctrl+F1"></MenuItem>
-                    <MenuItem x:Name="menu_item_logout" Header="Logout" Click ="On_Logout" InputGestureText="Ctrl+F4" Template="{DynamicResource FinalSubMenuItemTemplate}"></MenuItem>
+                    <MenuItem x:Name="menu_item_logout" Header="Logout" Click ="On_Logout" InputGestureText="Ctrl+F4"></MenuItem>
+                    <MenuItem x:Name="menu_item_register" Header="Register" Click ="On_Register" InputGestureText="Ctrl+F2" Template="{DynamicResource FinalSubMenuItemTemplate}"/>
                     <Separator/>
                     <MenuItem Header="Exit" Click="ExitApp_Click" InputGestureText="Alt+F4" Template="{DynamicResource FinalSubMenuItemTemplate}"></MenuItem>
                 </MenuItem>

--- a/YouTravel/Agent/AgentMainWindow.xaml.cs
+++ b/YouTravel/Agent/AgentMainWindow.xaml.cs
@@ -469,10 +469,10 @@ namespace YouTravel.Agent
                 string str = HelpProvider.GetHelpKey(depObject);
                 HelpProvider.ShowHelp(str, this);
             }
-            //else
-            //{
-            //             HelpProvider.ShowHelp("index", this);
-            //         }
+            else
+            {
+                HelpProvider.ShowHelp("index", this);
+            }
         }
 
         private void ExitApp_Click(object sender, RoutedEventArgs e)

--- a/YouTravel/Agent/AgentMainWindow.xaml.cs
+++ b/YouTravel/Agent/AgentMainWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using YouTravel.Model;
+using YouTravel.Shared;
 using YouTravel.Util;
 
 namespace YouTravel.Agent
@@ -266,7 +267,7 @@ namespace YouTravel.Agent
             CmdViewPlaces = null;
             CmdViewReports = null;
 
-            // TODO: CmdLogin
+            CmdLogin = new RelayCommand(o => Login(), o => true);
             CmdLogout = null;
         }
         #endregion
@@ -311,9 +312,20 @@ namespace YouTravel.Agent
             }
         }
 
+        private void Login()
+        {
+            new Login().ShowDialog();
+            RefreshUser();
+        }
+
         private void Logout()
         {
             YouTravelContext.Logout();
+            RefreshUser();
+        }
+
+        private void RefreshUser()
+        {
             InitWindowForUser();
             // FIXME: Doesn't clear out the last entry for some reason
             ClearNavigationHistory();
@@ -377,7 +389,7 @@ namespace YouTravel.Agent
         // TODO: Login
         private void On_Login(object sender, RoutedEventArgs e)
         {
-
+            Login();
         }
 
         private void On_Logout(object sender, RoutedEventArgs e)

--- a/YouTravel/Agent/AgentMainWindow.xaml.cs
+++ b/YouTravel/Agent/AgentMainWindow.xaml.cs
@@ -328,10 +328,13 @@ namespace YouTravel.Agent
 
         private void Login()
         {
-            new Login().ShowDialog();
-            RefreshUser();
-            Debug.Assert(YouTravelContext.User != null);
-            new OkBox($"Welcome {YouTravelContext.User.Username}.").ShowDialog();
+            bool? res = new Login().ShowDialog();
+            if (res ?? false)
+            {
+                RefreshUser();
+                Debug.Assert(YouTravelContext.User != null);
+                new OkBox($"Welcome {YouTravelContext.User.Username}.").ShowDialog();
+            }
         }
 
         private void Register()

--- a/YouTravel/Agent/AgentMainWindow.xaml.cs
+++ b/YouTravel/Agent/AgentMainWindow.xaml.cs
@@ -354,7 +354,6 @@ namespace YouTravel.Agent
             var user = YouTravelContext.User;
             YouTravelContext.Logout();
             RefreshUser();
-            new OkBox($"Goodbye {user.Username}.").ShowDialog();
         }
 
         private void RefreshUser()

--- a/YouTravel/Agent/AgentMainWindow.xaml.cs
+++ b/YouTravel/Agent/AgentMainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -329,6 +330,8 @@ namespace YouTravel.Agent
         {
             new Login().ShowDialog();
             RefreshUser();
+            Debug.Assert(YouTravelContext.User != null);
+            new OkBox($"Welcome {YouTravelContext.User.Username}.").ShowDialog();
         }
 
         private void Register()
@@ -338,15 +341,17 @@ namespace YouTravel.Agent
             var user = register.DialogResult;
             if (user != null)
             {
-                YouTravelContext.Login(user.Username, user.Password);
-                RefreshUser();
+                new OkBox($"Successfully registered {user.Username}.").ShowDialog();
             }
         }
 
         private void Logout()
         {
+            Debug.Assert(YouTravelContext.User != null);
+            var user = YouTravelContext.User;
             YouTravelContext.Logout();
             RefreshUser();
+            new OkBox($"Goodbye {user.Username}.").ShowDialog();
         }
 
         private void RefreshUser()

--- a/YouTravel/Agent/AgentMainWindow.xaml.cs
+++ b/YouTravel/Agent/AgentMainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using YouTravel.Model;
 using YouTravel.Util;
 
 namespace YouTravel.Agent
@@ -14,20 +15,88 @@ namespace YouTravel.Agent
         public ObservableCollection<Button> ToolbarBtn_Arrangement { get; set; } = new();
         public ObservableCollection<Button> ToolbarBtn_Place { get; set; } = new();
 
-        public ICommand CmdNavigateBack { get; private set; }
-        public ICommand CmdNavigateForward { get; private set; }
-        public ICommand CmdNewArrangement { get; private set; }
-        public ICommand CmdViewArrangements { get; private set; }
-        public ICommand CmdNewPlace { get; private set; }
-        public ICommand CmdViewPlaces { get; private set; }
-        public ICommand CmdViewReports { get; private set; }
-        public ICommand CmdToggleToolbar { get; private set; }
+        public ICommand? CmdNavigateBack { get; private set; }
+        public ICommand? CmdNavigateForward { get; private set; }
+        public ICommand? CmdNewArrangement { get; private set; }
+        public ICommand? CmdViewArrangements { get; private set; }
+        public ICommand? CmdNewPlace { get; private set; }
+        public ICommand? CmdViewPlaces { get; private set; }
+        public ICommand? CmdViewReports { get; private set; }
+        public ICommand? CmdToggleToolbar { get; private set; }
 
         public AgentMainWindow()
         {
             InitializeComponent();
             DataContext = this;
 
+            InitWindowForUser();
+        }
+
+        #region InitWindowForUser
+
+        #region InitUser
+        private void InitWindowForUser()
+        {
+            switch (YouTravelContext.User?.Type)
+            {
+                case UserType.AGENT:
+                    InitAgent();
+                    break;
+                case UserType.CLIENT:
+                    InitClient();
+                    break;
+                default:
+                    InitGuest();
+                    break;
+            }
+        }
+
+        private void InitAgent()
+        {
+            InitAgentMenu();
+            InitAgentToolbar();
+            InitAgentCommands();
+        }
+
+        private void InitClient()
+        {
+            InitClientMenu();
+            InitClientToolbar();
+            InitClientCommands();
+        }
+
+        private void InitGuest()
+        {
+            InitGuestMenu();
+            InitGuestToolbar();
+            InitGuestCommands();
+        }
+        #endregion
+
+        #region InitMenu
+        private void InitAgentMenu()
+        {
+
+        }
+
+        private void InitClientMenu()
+        {
+            menu_item_new.Visibility = Visibility.Collapsed;
+            menu_item_logout_separator.Visibility = Visibility.Collapsed;
+
+            menu_item_view_places.Visibility = Visibility.Collapsed;
+            menu_item_view_reports.Visibility = Visibility.Collapsed;
+        }
+
+        private void InitGuestMenu()
+        {
+            InitAgentMenu();
+        }
+        #endregion
+
+        #region InitToolbar
+        private void InitAgentToolbar()
+        {
             ToolbarBtn_Nav.Add(ToolbarButton.NewBtn("IcoArrowLeft.png", Back_Btn, "Navigate Backward (Ctrl+Left arrow)"));
             ToolbarBtn_Nav.Add(ToolbarButton.NewBtn("IcoArrowRight.png", Next_Btn, "Navigate Forward (Ctrl+Right arrow)"));
 
@@ -36,8 +105,26 @@ namespace YouTravel.Agent
 
             ToolbarBtn_Place.Add(ToolbarButton.NewBtn("IcoLocationAdd.png", On_AddPlace, "New Place (Ctrl+Shift+N)"));
             ToolbarBtn_Place.Add(ToolbarButton.NewBtn("IcoLocation.png", On_OpenPlaceList, "View Places (Ctrl+P)"));
+        }
 
-            #region InitCommands
+        private void InitClientToolbar()
+        {
+            toolbar_place.Visibility = Visibility.Collapsed;
+            ToolbarBtn_Nav.Add(ToolbarButton.NewBtn("IcoArrowLeft.png", Back_Btn, "Navigate Backward (Ctrl+Left arrow)"));
+            ToolbarBtn_Nav.Add(ToolbarButton.NewBtn("IcoArrowRight.png", Next_Btn, "Navigate Forward (Ctrl+Right arrow)"));
+
+            ToolbarBtn_Arrangement.Add(ToolbarButton.NewBtn("IcoTravel.png", On_OpenArrangementList, "View Arrangements (Ctrl+A)"));
+        }
+
+        private void InitGuestToolbar()
+        {
+            InitAgentToolbar();
+        }
+        #endregion
+
+        #region InitCommands
+        private void InitAgentCommands()
+        {
             CmdToggleToolbar = new RelayCommand(o => ToggleToolbar(), o => true);
 
             CmdNavigateBack = new RelayCommand(o => PageBack(), o => true);
@@ -49,8 +136,25 @@ namespace YouTravel.Agent
             CmdNewPlace = new RelayCommand(o => OpenPage(new LocationAdd(true)), o => true);
             CmdViewPlaces = new RelayCommand(o => OpenPage(new PlacesList()), o => true);
             CmdViewReports = new RelayCommand(o => OpenPage(new MonthlyReports()), o => true);
-            #endregion
         }
+
+        private void InitClientCommands()
+        {
+            CmdToggleToolbar = new RelayCommand(o => ToggleToolbar(), o => true);
+
+            CmdNavigateBack = new RelayCommand(o => PageBack(), o => true);
+            CmdNavigateForward = new RelayCommand(o => PageNext(), o => true);
+
+            CmdViewArrangements = new RelayCommand(o => OpenPage(new ArrangementList()), o => true);
+        }
+
+        private void InitGuestCommands()
+        {
+            InitAgentCommands();
+        }
+        #endregion
+
+        #endregion
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
@@ -64,7 +168,7 @@ namespace YouTravel.Agent
 
         public void OpenPage(Page page)
         {
-            Mouse.OverrideCursor = System.Windows.Input.Cursors.Wait;
+            Mouse.OverrideCursor = Cursors.Wait;
             myFrame.NavigationService.Navigate(page);
         }
 

--- a/YouTravel/Agent/AgentMainWindow.xaml.cs
+++ b/YouTravel/Agent/AgentMainWindow.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -7,22 +9,86 @@ using YouTravel.Util;
 
 namespace YouTravel.Agent
 {
-    public partial class AgentMainWindow : Window
+    public partial class AgentMainWindow : Window, INotifyPropertyChanged
     {
+        public event PropertyChangedEventHandler? PropertyChanged;
+        void DoPropertyChanged(string prop) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+
         public UserConfig UserConfig { get; } = YouTravelContext.UserConfig;
 
         public ObservableCollection<Button> ToolbarBtn_Nav { get; set; } = new();
         public ObservableCollection<Button> ToolbarBtn_Arrangement { get; set; } = new();
         public ObservableCollection<Button> ToolbarBtn_Place { get; set; } = new();
 
-        public ICommand? CmdNavigateBack { get; private set; }
-        public ICommand? CmdNavigateForward { get; private set; }
-        public ICommand? CmdNewArrangement { get; private set; }
-        public ICommand? CmdViewArrangements { get; private set; }
-        public ICommand? CmdNewPlace { get; private set; }
-        public ICommand? CmdViewPlaces { get; private set; }
-        public ICommand? CmdViewReports { get; private set; }
-        public ICommand? CmdToggleToolbar { get; private set; }
+        public ICommand? _cmdNavigateBack;
+        public ICommand? CmdNavigateBack
+        { 
+            get { return _cmdNavigateBack;}
+            private set { _cmdNavigateBack = value; DoPropertyChanged(nameof(CmdNavigateBack)); }
+        }
+
+        public ICommand? _cmdNavigateForward;
+        public ICommand? CmdNavigateForward
+        { 
+            get { return _cmdNavigateForward; }
+            private set { _cmdNavigateForward = value; DoPropertyChanged(nameof(CmdNavigateForward)); }
+        }
+
+        public ICommand? _cmdNewArrangement;
+        public ICommand? CmdNewArrangement
+        { 
+            get { return _cmdNewArrangement; }
+            private set { _cmdNewArrangement = value; DoPropertyChanged(nameof(CmdNewArrangement)); }
+        }
+
+        public ICommand? _cmdViewArrangements;
+        public ICommand? CmdViewArrangements
+        { 
+            get { return _cmdViewArrangements; }
+            private set { _cmdViewArrangements = value; DoPropertyChanged(nameof(CmdViewArrangements)); }
+        }
+
+        public ICommand? _cmdNewPlace;
+        public ICommand? CmdNewPlace
+        { 
+            get { return _cmdNewPlace; }
+            private set { _cmdNewPlace = value; DoPropertyChanged(nameof(CmdNewPlace)); }
+        }
+
+        public ICommand? _cmdViewPlaces;
+        public ICommand? CmdViewPlaces
+        { 
+            get { return _cmdViewPlaces; }
+            private set { _cmdViewPlaces = value; DoPropertyChanged(nameof(CmdViewPlaces)); }
+        }
+
+        public ICommand? _cmdViewReports;
+        public ICommand? CmdViewReports
+        { 
+            get { return _cmdViewReports; }
+            private set { _cmdViewReports = value; DoPropertyChanged(nameof(CmdViewReports)); }
+        }
+
+        public ICommand? _cmdToggleToolbar;
+        public ICommand? CmdToggleToolbar
+        { 
+            get { return _cmdToggleToolbar; }
+            private set { _cmdToggleToolbar = value; DoPropertyChanged(nameof(CmdToggleToolbar)); }
+        }
+
+        public ICommand? _cmdLogin;
+        public ICommand? CmdLogin
+        { 
+            get { return _cmdLogin; }
+            private set { _cmdLogin = value; DoPropertyChanged(nameof(CmdLogin)); }
+        }
+
+        public ICommand? _cmdLogout;
+        public ICommand? CmdLogout
+        { 
+            get { return _cmdLogout; }
+            private set { _cmdLogout = value; DoPropertyChanged(nameof(CmdLogout)); }
+        }
 
         public AgentMainWindow()
         {
@@ -76,33 +142,55 @@ namespace YouTravel.Agent
         #region InitMenu
         private void InitAgentMenu()
         {
+            menu_item_new.Visibility = Visibility.Visible;
+            menu_item_login_separator.Visibility = Visibility.Visible;
 
+            menu_item_view_places.Visibility = Visibility.Visible;
+            menu_item_view_reports.Visibility = Visibility.Visible;
+
+            menu_item_login.Visibility = Visibility.Collapsed;
+            menu_item_logout.Visibility = Visibility.Visible;
         }
 
         private void InitClientMenu()
         {
             menu_item_new.Visibility = Visibility.Collapsed;
-            menu_item_logout_separator.Visibility = Visibility.Collapsed;
+            menu_item_login_separator.Visibility = Visibility.Collapsed;
 
             menu_item_view_places.Visibility = Visibility.Collapsed;
             menu_item_view_reports.Visibility = Visibility.Collapsed;
+
+            menu_item_login.Visibility = Visibility.Collapsed;
+            menu_item_logout.Visibility = Visibility.Visible;
         }
 
         private void InitGuestMenu()
         {
-            InitAgentMenu();
+            menu_item_new.Visibility = Visibility.Collapsed;
+            menu_item_login_separator.Visibility = Visibility.Collapsed;
+
+            menu_item_view_places.Visibility = Visibility.Collapsed;
+            menu_item_view_reports.Visibility = Visibility.Collapsed;
+
+            menu_item_login.Visibility = Visibility.Visible;
+            menu_item_logout.Visibility = Visibility.Collapsed;
         }
         #endregion
 
         #region InitToolbar
         private void InitAgentToolbar()
         {
+            toolbar_place.Visibility = Visibility.Visible;
+
+            ToolbarBtn_Nav.Clear();
             ToolbarBtn_Nav.Add(ToolbarButton.NewBtn("IcoArrowLeft.png", Back_Btn, "Navigate Backward (Ctrl+Left arrow)"));
             ToolbarBtn_Nav.Add(ToolbarButton.NewBtn("IcoArrowRight.png", Next_Btn, "Navigate Forward (Ctrl+Right arrow)"));
 
+            ToolbarBtn_Arrangement.Clear();
             ToolbarBtn_Arrangement.Add(ToolbarButton.NewBtn("IcoPlanetAdd.png", On_AddArrangement, "New Arrangement (Ctrl+N)"));
             ToolbarBtn_Arrangement.Add(ToolbarButton.NewBtn("IcoTravel.png", On_OpenArrangementList, "View Arrangements (Ctrl+A)"));
 
+            ToolbarBtn_Place.Clear();
             ToolbarBtn_Place.Add(ToolbarButton.NewBtn("IcoLocationAdd.png", On_AddPlace, "New Place (Ctrl+Shift+N)"));
             ToolbarBtn_Place.Add(ToolbarButton.NewBtn("IcoLocation.png", On_OpenPlaceList, "View Places (Ctrl+P)"));
         }
@@ -110,15 +198,20 @@ namespace YouTravel.Agent
         private void InitClientToolbar()
         {
             toolbar_place.Visibility = Visibility.Collapsed;
+
+            ToolbarBtn_Nav.Clear();
             ToolbarBtn_Nav.Add(ToolbarButton.NewBtn("IcoArrowLeft.png", Back_Btn, "Navigate Backward (Ctrl+Left arrow)"));
             ToolbarBtn_Nav.Add(ToolbarButton.NewBtn("IcoArrowRight.png", Next_Btn, "Navigate Forward (Ctrl+Right arrow)"));
 
+            ToolbarBtn_Arrangement.Clear();
             ToolbarBtn_Arrangement.Add(ToolbarButton.NewBtn("IcoTravel.png", On_OpenArrangementList, "View Arrangements (Ctrl+A)"));
+
+            ToolbarBtn_Place.Clear();
         }
 
         private void InitGuestToolbar()
         {
-            InitAgentToolbar();
+            InitClientToolbar();
         }
         #endregion
 
@@ -136,6 +229,9 @@ namespace YouTravel.Agent
             CmdNewPlace = new RelayCommand(o => OpenPage(new LocationAdd(true)), o => true);
             CmdViewPlaces = new RelayCommand(o => OpenPage(new PlacesList()), o => true);
             CmdViewReports = new RelayCommand(o => OpenPage(new MonthlyReports()), o => true);
+
+            CmdLogin = null;
+            CmdLogout = new RelayCommand(o => Logout(), o => true);
         }
 
         private void InitClientCommands()
@@ -145,12 +241,33 @@ namespace YouTravel.Agent
             CmdNavigateBack = new RelayCommand(o => PageBack(), o => true);
             CmdNavigateForward = new RelayCommand(o => PageNext(), o => true);
 
+            CmdNewArrangement = null;
             CmdViewArrangements = new RelayCommand(o => OpenPage(new ArrangementList()), o => true);
+
+            CmdNewPlace = null;
+            CmdViewPlaces = null;
+            CmdViewReports = null;
+
+            CmdLogin = null;
+            CmdLogout = new RelayCommand(o => Logout(), o => true);
         }
 
         private void InitGuestCommands()
         {
-            InitAgentCommands();
+            CmdToggleToolbar = new RelayCommand(o => ToggleToolbar(), o => true);
+
+            CmdNavigateBack = new RelayCommand(o => PageBack(), o => true);
+            CmdNavigateForward = new RelayCommand(o => PageNext(), o => true);
+
+            CmdNewArrangement = null;
+            CmdViewArrangements = new RelayCommand(o => OpenPage(new ArrangementList()), o => true);
+
+            CmdNewPlace = null;
+            CmdViewPlaces = null;
+            CmdViewReports = null;
+
+            // TODO: CmdLogin
+            CmdLogout = null;
         }
         #endregion
 
@@ -169,28 +286,46 @@ namespace YouTravel.Agent
         public void OpenPage(Page page)
         {
             Mouse.OverrideCursor = Cursors.Wait;
-            myFrame.NavigationService.Navigate(page);
+            myFrame.Navigate(page);
         }
 
         public void CloseMostRecentPage()
         {
             PageBack();
-            myFrame.NavigationService.RemoveBackEntry();
+            myFrame.RemoveBackEntry();
         }
 
         public void PageBack()
         {
-            if (myFrame.NavigationService.CanGoBack)
+            if (myFrame.CanGoBack)
             {
-                myFrame.NavigationService.GoBack();
+                myFrame.GoBack();
             }
         }
 
         public void PageNext()
         {
-            if (myFrame.NavigationService.CanGoForward)
+            if (myFrame.CanGoForward)
             {
-                myFrame.NavigationService.GoForward();
+                myFrame.GoForward();
+            }
+        }
+
+        private void Logout()
+        {
+            YouTravelContext.Logout();
+            InitWindowForUser();
+            // FIXME: Doesn't clear out the last entry for some reason
+            ClearNavigationHistory();
+            OpenPage(new ArrangementList());
+        }
+
+        private void ClearNavigationHistory()
+        {
+            var entry = myFrame.RemoveBackEntry();
+            while (entry != null)
+            {
+                entry = myFrame.RemoveBackEntry();
             }
         }
 
@@ -198,10 +333,10 @@ namespace YouTravel.Agent
         {
             // TODO: Hardcoded everything...
 
-            ToolbarBtn_Nav[0].IsEnabled = myFrame.NavigationService.CanGoBack;
+            ToolbarBtn_Nav[0].IsEnabled = myFrame.CanGoBack;
             ((Image)ToolbarBtn_Nav[0].Content).Opacity = myFrame.CanGoBack ? 1 : 0.5;
 
-            ToolbarBtn_Nav[1].IsEnabled = myFrame.NavigationService.CanGoForward;
+            ToolbarBtn_Nav[1].IsEnabled = myFrame.CanGoForward;
             ((Image)ToolbarBtn_Nav[1].Content).Opacity = myFrame.CanGoForward ? 1 : 0.5;
         }
 
@@ -237,6 +372,17 @@ namespace YouTravel.Agent
         private void On_AddPlace(object sender, RoutedEventArgs e)
         {
             OpenPage(new LocationAdd(true));
+        }
+
+        // TODO: Login
+        private void On_Login(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+        private void On_Logout(object sender, RoutedEventArgs e)
+        {
+            Logout();
         }
 
         private void On_MonthlyReports(object sender, RoutedEventArgs e)

--- a/YouTravel/Agent/AgentMainWindow.xaml.cs
+++ b/YouTravel/Agent/AgentMainWindow.xaml.cs
@@ -91,6 +91,13 @@ namespace YouTravel.Agent
             private set { _cmdLogout = value; DoPropertyChanged(nameof(CmdLogout)); }
         }
 
+        public ICommand? _cmdRegister;
+        public ICommand? CmdRegister
+        {
+            get { return _cmdRegister; }
+            private set { _cmdRegister = value; DoPropertyChanged(nameof(CmdRegister)); }
+        }
+
         public AgentMainWindow()
         {
             InitializeComponent();
@@ -151,6 +158,7 @@ namespace YouTravel.Agent
 
             menu_item_login.Visibility = Visibility.Collapsed;
             menu_item_logout.Visibility = Visibility.Visible;
+            menu_item_register.Visibility = Visibility.Collapsed;
         }
 
         private void InitClientMenu()
@@ -163,6 +171,7 @@ namespace YouTravel.Agent
 
             menu_item_login.Visibility = Visibility.Collapsed;
             menu_item_logout.Visibility = Visibility.Visible;
+            menu_item_register.Visibility = Visibility.Collapsed;
         }
 
         private void InitGuestMenu()
@@ -175,6 +184,7 @@ namespace YouTravel.Agent
 
             menu_item_login.Visibility = Visibility.Visible;
             menu_item_logout.Visibility = Visibility.Collapsed;
+            menu_item_register.Visibility = Visibility.Visible;
         }
         #endregion
 
@@ -233,6 +243,7 @@ namespace YouTravel.Agent
 
             CmdLogin = null;
             CmdLogout = new RelayCommand(o => Logout(), o => true);
+            CmdRegister = null;
         }
 
         private void InitClientCommands()
@@ -251,6 +262,7 @@ namespace YouTravel.Agent
 
             CmdLogin = null;
             CmdLogout = new RelayCommand(o => Logout(), o => true);
+            CmdRegister = null;
         }
 
         private void InitGuestCommands()
@@ -269,6 +281,7 @@ namespace YouTravel.Agent
 
             CmdLogin = new RelayCommand(o => Login(), o => true);
             CmdLogout = null;
+            CmdRegister = new RelayCommand(o => Register(), o => true);
         }
         #endregion
 
@@ -316,6 +329,18 @@ namespace YouTravel.Agent
         {
             new Login().ShowDialog();
             RefreshUser();
+        }
+
+        private void Register()
+        {
+            var register = new Register();
+            register.ShowDialog();
+            var user = register.DialogResult;
+            if (user != null)
+            {
+                YouTravelContext.Login(user.Username, user.Password);
+                RefreshUser();
+            }
         }
 
         private void Logout()
@@ -386,7 +411,6 @@ namespace YouTravel.Agent
             OpenPage(new LocationAdd(true));
         }
 
-        // TODO: Login
         private void On_Login(object sender, RoutedEventArgs e)
         {
             Login();
@@ -395,6 +419,11 @@ namespace YouTravel.Agent
         private void On_Logout(object sender, RoutedEventArgs e)
         {
             Logout();
+        }
+
+        private void On_Register(object sender, RoutedEventArgs e)
+        {
+            Register();
         }
 
         private void On_MonthlyReports(object sender, RoutedEventArgs e)

--- a/YouTravel/Agent/AgentMainWindow.xaml.cs
+++ b/YouTravel/Agent/AgentMainWindow.xaml.cs
@@ -8,7 +8,7 @@ namespace YouTravel.Agent
 {
     public partial class AgentMainWindow : Window
     {
-        public UserConfig UserConfig { get; } = UserConfig.Instance;
+        public UserConfig UserConfig { get; } = YouTravelContext.UserConfig;
 
         public ObservableCollection<Button> ToolbarBtn_Nav { get; set; } = new();
         public ObservableCollection<Button> ToolbarBtn_Arrangement { get; set; } = new();

--- a/YouTravel/Agent/Settings.xaml
+++ b/YouTravel/Agent/Settings.xaml
@@ -73,9 +73,9 @@
                     </Style>
                 </StackPanel.Style>
 
-                <CheckBox VerticalAlignment="Center" VerticalContentAlignment="Center" Content="Navigation" IsChecked="{Binding ToolbarShowNav,Mode=TwoWay}"/>
-                <CheckBox VerticalAlignment="Center" VerticalContentAlignment="Center" Content="Arrangement" IsChecked="{Binding ToolbarShowArrangement,Mode=TwoWay}"/>
-                <CheckBox VerticalAlignment="Center" VerticalContentAlignment="Center" Content="Place" IsChecked="{Binding ToolbarShowPlace,Mode=TwoWay}"/>
+                <CheckBox x:Name="toolbar_cb_navigation" VerticalAlignment="Center" VerticalContentAlignment="Center" Content="Navigation" IsChecked="{Binding ToolbarShowNav,Mode=TwoWay}"/>
+                <CheckBox x:Name="toolbar_cb_arrangement" VerticalAlignment="Center" VerticalContentAlignment="Center" Content="Arrangement" IsChecked="{Binding ToolbarShowArrangement,Mode=TwoWay}"/>
+                <CheckBox x:Name="toolbar_cb_place" VerticalAlignment="Center" VerticalContentAlignment="Center" Content="Place" IsChecked="{Binding ToolbarShowPlace,Mode=TwoWay}"/>
             </StackPanel>
         </Grid>
 

--- a/YouTravel/Agent/Settings.xaml.cs
+++ b/YouTravel/Agent/Settings.xaml.cs
@@ -69,7 +69,7 @@ namespace YouTravel.Agent
 
         private void InitAgent()
         {
-
+            toolbar_cb_place.Visibility = Visibility.Visible;
         }
 
         private void InitClient()
@@ -79,7 +79,7 @@ namespace YouTravel.Agent
 
         private void InitGuest()
         {
-            InitAgent();
+            InitClient();
         }
         #endregion
 

--- a/YouTravel/Agent/Settings.xaml.cs
+++ b/YouTravel/Agent/Settings.xaml.cs
@@ -26,7 +26,7 @@ namespace YouTravel.Agent
         public event PropertyChangedEventHandler? PropertyChanged;
         void DoPropertyChanged(string prop) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
 
-        public UserConfig UserConfig { get; } = UserConfig.Instance;
+        public UserConfig UserConfig { get; } = YouTravelContext.UserConfig;
 
         private string? _selectedSection;
         public string? SelectedSection { get { return _selectedSection; } set { _selectedSection = value; DoPropertyChanged(nameof(SelectedSection)); } }

--- a/YouTravel/Agent/Settings.xaml.cs
+++ b/YouTravel/Agent/Settings.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using YouTravel.Model;
 using YouTravel.Util;
 
 namespace YouTravel.Agent
@@ -45,7 +46,43 @@ namespace YouTravel.Agent
             }
             DataContext = this;
             Owner = Application.Current.MainWindow;
+
+            InitWindowForUser();
         }
+
+        #region InitWindowForUser
+        private void InitWindowForUser()
+        {
+            switch (YouTravelContext.User?.Type)
+            {
+                case UserType.AGENT:
+                    InitAgent();
+                    break;
+                case UserType.CLIENT:
+                    InitClient();
+                    break;
+                default:
+                    InitGuest();
+                    break;
+            }
+        }
+
+        private void InitAgent()
+        {
+
+        }
+
+        private void InitClient()
+        {
+            toolbar_cb_place.Visibility = Visibility.Collapsed;
+        }
+
+        private void InitGuest()
+        {
+            InitAgent();
+        }
+        #endregion
+
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {

--- a/YouTravel/App.xaml
+++ b/YouTravel/App.xaml
@@ -122,9 +122,14 @@
 		<Style TargetType="{x:Type TextBox}">
 			<Setter Property="Background" Value="{DynamicResource bg_dark1}"/>
 			<Setter Property="Foreground" Value="White"/>
-		</Style>
+        </Style>
 
-		<Style TargetType="{x:Type ListBox}">
+        <Style TargetType="{x:Type PasswordBox}">
+            <Setter Property="Background" Value="{DynamicResource bg_dark1}"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+
+        <Style TargetType="{x:Type ListBox}">
 			<Setter Property="Background" Value="{DynamicResource bg_dark0}"/>
 			<Setter Property="Foreground" Value="White"/>
 		</Style>

--- a/YouTravel/App.xaml.cs
+++ b/YouTravel/App.xaml.cs
@@ -53,8 +53,8 @@ namespace YouTravel
                 db.Reservations.Add(res);
             }
 
-            var client = new User { Type = UserType.CLIENT, Username = "client" };
-            var agent = new User { Type = UserType.AGENT, Username = "agent" };
+            var client = new User { Type = UserType.CLIENT, Username = "client", Password = "123" };
+            var agent = new User { Type = UserType.AGENT, Username = "agent", Password = "123" };
             db.Users.Add(client);
             db.Users.Add(agent);
 

--- a/YouTravel/App.xaml.cs
+++ b/YouTravel/App.xaml.cs
@@ -15,8 +15,6 @@ namespace YouTravel
 
         private static void FakeMain()
         {
-            UserConfig.Instance.LoadToolbarConfig();
-
             using var db = new TravelContext();
             // Add:
 

--- a/YouTravel/App.xaml.cs
+++ b/YouTravel/App.xaml.cs
@@ -55,6 +55,11 @@ namespace YouTravel
                 db.Reservations.Add(res);
             }
 
+            var client = new User { Type = UserType.CLIENT, Username = "client" };
+            var agent = new User { Type = UserType.AGENT, Username = "agent" };
+            db.Users.Add(client);
+            db.Users.Add(agent);
+
             db.SaveChanges();
 
             Console.WriteLine("Opening window...");

--- a/YouTravel/Model/TravelContext.cs
+++ b/YouTravel/Model/TravelContext.cs
@@ -7,6 +7,8 @@ namespace YouTravel.Model
         public DbSet<Arrangement> Arrangements { get; set; }
         public DbSet<Place> Places { get; set; }
         public DbSet<Reservation> Reservations { get; set; }
+        public DbSet<User> Users { get; set; }
+
 
         private static bool _created = false;
         public TravelContext()

--- a/YouTravel/Model/User.cs
+++ b/YouTravel/Model/User.cs
@@ -8,8 +8,11 @@ namespace YouTravel.Model
     {
         [Key]
         public int Id { get; set; }
-        public UserType Type { get; set; }
-        public string? Username { get; set; }
-        public string? Password { get; set; }
+        public UserType Type { get; set; } = UserType.CLIENT;
+        public string Username { get; set; } = "";
+        public string? Name { get; set; }
+        public string? Surname { get; set; }
+        public string? Email { get; set; }
+        public string Password { get; set; } = "";
     }
 }

--- a/YouTravel/Model/User.cs
+++ b/YouTravel/Model/User.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace YouTravel.Model
+{
+    public enum UserType { CLIENT, AGENT, }
+    public class User
+    {
+        [Key]
+        public int Id { get; set; }
+        public UserType Type { get; set; }
+        public string? Username { get; set; }
+    }
+}

--- a/YouTravel/Model/User.cs
+++ b/YouTravel/Model/User.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace YouTravel.Model
 {
@@ -9,5 +10,6 @@ namespace YouTravel.Model
         public int Id { get; set; }
         public UserType Type { get; set; }
         public string? Username { get; set; }
+        public string? Password { get; set; }
     }
 }

--- a/YouTravel/Shared/Login.xaml
+++ b/YouTravel/Shared/Login.xaml
@@ -1,0 +1,76 @@
+﻿<Window x:Class="YouTravel.Shared.Login"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:YouTravel.Shared"
+        mc:Ignorable="d"
+        Title="Login" Height="250" Width="400"
+        ResizeMode="NoResize"
+        Style="{StaticResource WinDark}">
+    <Grid Margin="10 0 10 0" VerticalAlignment="Center">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Label 
+            Grid.Row="0"
+            Grid.ColumnSpan="2" 
+            Content="Username" />
+        <TextBox
+            x:Name="tbUsername" 
+            ToolTip="Enter username"
+            Margin="0 0 0 10"
+            Grid.Row="1" 
+            Grid.ColumnSpan="2"
+            MinHeight="32" 
+            Text="{Binding Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+            VerticalContentAlignment="Center" 
+            KeyUp="TbUsername_KeyUp"/>
+
+        <Label 
+            Grid.Row="2"
+            Grid.ColumnSpan="2"
+            Content="Password" />
+        <TextBox 
+            x:Name="tbPassword" 
+            ToolTip="Enter password"
+            Margin="0 0 0 10"
+            Grid.Row="3"
+            Grid.ColumnSpan="2" 
+            MinHeight="32"
+            Text="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            VerticalContentAlignment="Center"
+            KeyUp="TbPassword_KeyUp"/>
+
+        <Label
+            Height="32"
+            VerticalAlignment="Center"
+            Foreground="IndianRed" 
+            Grid.Row="4"
+            Grid.Column="0"
+            Content="{Binding ErrorText, Mode=TwoWay}" />
+
+        <StackPanel 
+            Grid.Row="4" 
+            Grid.Column="1"
+            Orientation="Horizontal" 
+            HorizontalAlignment="Right">
+            <Button 
+                Margin="0 0 10 0" 
+                Content="Cancel"
+                Click="Cancel_Click"/>
+            <Button 
+                Content="Login"
+                Click="Login_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/YouTravel/Shared/Login.xaml
+++ b/YouTravel/Shared/Login.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:YouTravel.Shared"
         mc:Ignorable="d"
-        Title="Login" Height="300" Width="400"
+        Title="Login" Height="350" Width="400"
         ResizeMode="NoResize"
         Style="{StaticResource WinDark}"
         KeyUp="Window_KeyUp">
@@ -15,6 +15,7 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -51,22 +52,22 @@
             Grid.ColumnSpan="2" 
             x:Name="tbPassword" 
             ToolTip="Enter password"
-            Margin="0 0 0 20"
+            Margin="0 0 0 10"
             MinHeight="32"
             Text="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             VerticalContentAlignment="Center"
             KeyUp="TbPassword_KeyUp"/>
 
         <Label
-            Grid.Row="4"
+            Grid.Row="5"
             Grid.Column="0"
-            Height="32"
-            VerticalAlignment="Center"
             Foreground="IndianRed" 
+            Margin="0 0 0 10"
+            Height="32"
             Content="{Binding ErrorText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <StackPanel 
-            Grid.Row="5" 
+            Grid.Row="6" 
             Grid.ColumnSpan="2"
             Orientation="Horizontal" 
             HorizontalAlignment="Center">

--- a/YouTravel/Shared/Login.xaml
+++ b/YouTravel/Shared/Login.xaml
@@ -6,6 +6,7 @@
         xmlns:local="clr-namespace:YouTravel.Shared"
         mc:Ignorable="d"
         Title="Login" Height="350" Width="400"
+        WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         Style="{StaticResource WinDark}"
         KeyUp="Window_KeyUp">

--- a/YouTravel/Shared/Login.xaml
+++ b/YouTravel/Shared/Login.xaml
@@ -47,14 +47,14 @@
             Grid.Row="3"
             Grid.ColumnSpan="2"
             Content="Password" />
-        <TextBox 
+        <PasswordBox
             Grid.Row="4"
             Grid.ColumnSpan="2" 
             x:Name="tbPassword" 
             ToolTip="Enter password"
             Margin="0 0 0 10"
             MinHeight="32"
-            Text="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            PasswordChanged="TbPassword_PasswordChanged"
             VerticalContentAlignment="Center"
             KeyUp="TbPassword_KeyUp"/>
 
@@ -72,16 +72,16 @@
             Orientation="Horizontal" 
             HorizontalAlignment="Center">
             <Button 
+                Content="Login"
+                MinHeight="32"
+                MinWidth="80"
+                Click="Login_Click"/>
+            <Button 
                 Margin="0 0 10 0" 
                 Content="Cancel"
                 MinHeight="32"
                 MinWidth="80"
                 Click="Cancel_Click"/>
-            <Button 
-                Content="Login"
-                MinHeight="32"
-                MinWidth="80"
-                Click="Login_Click"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/YouTravel/Shared/Login.xaml
+++ b/YouTravel/Shared/Login.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:YouTravel.Shared"
         mc:Ignorable="d"
-        Title="Login" Height="250" Width="400"
+        Title="Login" Height="300" Width="400"
         ResizeMode="NoResize"
         Style="{StaticResource WinDark}"
         KeyUp="Window_KeyUp">
@@ -20,57 +20,66 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
+        <Label
+            Grid.Row="0"
+            Content="Login"
+            FontSize="28"/>
 
         <Label 
-            Grid.Row="0"
+            Grid.Row="1"
             Grid.ColumnSpan="2" 
             Content="Username" />
         <TextBox
+            Grid.Row="2" 
+            Grid.ColumnSpan="2"
             x:Name="tbUsername" 
             ToolTip="Enter username"
             Margin="0 0 0 10"
-            Grid.Row="1" 
-            Grid.ColumnSpan="2"
             MinHeight="32" 
             Text="{Binding Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
             VerticalContentAlignment="Center" 
             KeyUp="TbUsername_KeyUp"/>
 
         <Label 
-            Grid.Row="2"
+            Grid.Row="3"
             Grid.ColumnSpan="2"
             Content="Password" />
         <TextBox 
+            Grid.Row="4"
+            Grid.ColumnSpan="2" 
             x:Name="tbPassword" 
             ToolTip="Enter password"
-            Margin="0 0 0 10"
-            Grid.Row="3"
-            Grid.ColumnSpan="2" 
+            Margin="0 0 0 20"
             MinHeight="32"
             Text="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             VerticalContentAlignment="Center"
             KeyUp="TbPassword_KeyUp"/>
 
         <Label
+            Grid.Row="4"
+            Grid.Column="0"
             Height="32"
             VerticalAlignment="Center"
             Foreground="IndianRed" 
-            Grid.Row="4"
-            Grid.Column="0"
             Content="{Binding ErrorText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <StackPanel 
-            Grid.Row="4" 
-            Grid.Column="1"
+            Grid.Row="5" 
+            Grid.ColumnSpan="2"
             Orientation="Horizontal" 
-            HorizontalAlignment="Right">
+            HorizontalAlignment="Center">
             <Button 
                 Margin="0 0 10 0" 
                 Content="Cancel"
+                MinHeight="32"
+                MinWidth="80"
                 Click="Cancel_Click"/>
             <Button 
                 Content="Login"
+                MinHeight="32"
+                MinWidth="80"
                 Click="Login_Click"/>
         </StackPanel>
     </Grid>

--- a/YouTravel/Shared/Login.xaml
+++ b/YouTravel/Shared/Login.xaml
@@ -74,11 +74,11 @@
             HorizontalAlignment="Center">
             <Button 
                 Content="Login"
+                Margin="0 0 10 0" 
                 MinHeight="32"
                 MinWidth="80"
                 Click="Login_Click"/>
             <Button 
-                Margin="0 0 10 0" 
                 Content="Cancel"
                 MinHeight="32"
                 MinWidth="80"

--- a/YouTravel/Shared/Login.xaml.cs
+++ b/YouTravel/Shared/Login.xaml.cs
@@ -68,12 +68,13 @@ namespace YouTravel.Shared
 
         private void AttemptLogin()
         {
-            if (YouTravelContext.Login(Username, Password))
+            try
             {
+                YouTravelContext.Login(Username, Password);
                 // TODO: Play a sound or something fancy
                 Close();
             }
-            else
+            catch (LoginFailedException)
             {
                 ErrorText = "Wrong username or password";
             }
@@ -98,6 +99,14 @@ namespace YouTravel.Shared
             } else
             {
                 ErrorText = null;
+            }
+        }
+
+        private void Window_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
             }
         }
     }

--- a/YouTravel/Shared/Login.xaml.cs
+++ b/YouTravel/Shared/Login.xaml.cs
@@ -71,7 +71,7 @@ namespace YouTravel.Shared
             try
             {
                 YouTravelContext.Login(Username, Password);
-                // TODO: Play a sound or something fancy
+                DialogResult = true;
                 Close();
             }
             catch (LoginFailedException)

--- a/YouTravel/Shared/Login.xaml.cs
+++ b/YouTravel/Shared/Login.xaml.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using YouTravel.Util;
+
+namespace YouTravel.Shared
+{
+    /// <summary>
+    /// Interaction logic for Login.xaml
+    /// </summary>
+    public partial class Login : Window, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+        void DoPropertyChanged(string prop) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+
+        private string _username = "";
+        public string Username
+        {
+            get { return _username; }
+            set { _username = value; DoPropertyChanged(nameof(Username)); }
+        }
+
+        private string _password = "";
+        public string Password
+        { 
+            get { return _password; }
+            set { _password = value; DoPropertyChanged(nameof(Password)); }
+        }
+
+        private string? _errorText;
+        public string? ErrorText
+        { 
+            get { return _errorText; }
+            set { _errorText = value; DoPropertyChanged(nameof(ErrorText)); }
+        }
+
+        public Login()
+        {
+            InitializeComponent();
+            DataContext = this;
+
+            // TODO: Is this necessary if we call the window with ShowDialog() instead of Show()?
+            Owner = Application.Current.MainWindow;
+            tbUsername.Focus();
+        }
+
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void Login_Click(object sender, RoutedEventArgs e)
+        {
+            AttemptLogin();
+        }
+
+        private void AttemptLogin()
+        {
+            if (YouTravelContext.Login(Username, Password))
+            {
+                // TODO: Play a sound or something fancy
+                Close();
+            }
+            else
+            {
+                ErrorText = "Wrong username or password";
+            }
+        }
+
+        private void TbUsername_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                AttemptLogin();
+            } else
+            {
+                ErrorText = null;
+            }
+        }
+
+        private void TbPassword_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                AttemptLogin();
+            } else
+            {
+                ErrorText = null;
+            }
+        }
+    }
+}

--- a/YouTravel/Shared/Login.xaml.cs
+++ b/YouTravel/Shared/Login.xaml.cs
@@ -109,5 +109,10 @@ namespace YouTravel.Shared
                 Close();
             }
         }
+
+        private void TbPassword_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            Password = ((PasswordBox)sender).Password;
+        }
     }
 }

--- a/YouTravel/Shared/OkBox.xaml
+++ b/YouTravel/Shared/OkBox.xaml
@@ -1,0 +1,34 @@
+﻿<Window x:Class="YouTravel.Shared.OkBox"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:YouTravel.Shared"
+        mc:Ignorable="d"
+        Style="{StaticResource WinDark}"
+        WindowStartupLocation="CenterOwner"
+        Title="OkBox"
+        Height="200" Width="400"
+        KeyUp="Window_KeyUp">
+    <Window.Resources>
+        <BitmapImage x:Key="IcoHelp" UriSource="../Res/IcoHelp.png"/>
+        <BitmapImage x:Key="IcoInfo" UriSource="../Res/IcoInfo.png"/>
+    </Window.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+            <Image x:Name="imgIconInfo" Grid.Column="0" Source="{StaticResource IcoInfo}" Margin="16 32 0 32"/>
+            <TextBlock Grid.Column="1" TextWrapping="Wrap" Text="{Binding MessageBody}" VerticalAlignment="Center" Margin="16 0 4 0" d:Text="Dummy text"/>
+        </Grid>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="10 8 10 10" HorizontalAlignment="Center">
+            <Button x:Name="btnOk" Click="BtnOk_Click" Width="100" Height="32" Content="Ok"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/YouTravel/Shared/OkBox.xaml.cs
+++ b/YouTravel/Shared/OkBox.xaml.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Media;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using static YouTravel.Shared.ConfirmBox;
+
+namespace YouTravel.Shared
+{
+    /// <summary>
+    /// Interaction logic for OkBox.xaml
+    /// </summary>
+    public partial class OkBox : Window
+    {
+        public string MessageBody { get; set; }
+
+        public OkBox(string messageBody)
+        {
+            InitializeComponent();
+            DataContext = this;
+            MessageBody = messageBody;
+
+            Owner = Application.Current.MainWindow;
+
+            SetIcon();
+        }
+
+        private void SetIcon()
+        {
+            imgIconInfo.Visibility = Visibility.Collapsed;
+            SystemSounds.Beep.Play();
+            imgIconInfo.Visibility = Visibility.Visible;
+        }
+
+        private void BtnOk_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void Window_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter || e.Key == Key.Escape)
+            {
+                Close();
+            }
+        }
+    }
+}

--- a/YouTravel/Shared/Register.xaml
+++ b/YouTravel/Shared/Register.xaml
@@ -1,11 +1,11 @@
-﻿<Window x:Class="YouTravel.Shared.Login"
+﻿<Window x:Class="YouTravel.Shared.Register"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:YouTravel.Shared"
         mc:Ignorable="d"
-        Title="Login" Height="250" Width="400"
+        Title="Register" Height="450" Width="400"
         ResizeMode="NoResize"
         Style="{StaticResource WinDark}"
         KeyUp="Window_KeyUp">
@@ -20,6 +20,12 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Label 
@@ -27,11 +33,11 @@
             Grid.ColumnSpan="2" 
             Content="Username" />
         <TextBox
+            Grid.Row="1" 
+            Grid.ColumnSpan="2"
             x:Name="tbUsername" 
             ToolTip="Enter username"
             Margin="0 0 0 10"
-            Grid.Row="1" 
-            Grid.ColumnSpan="2"
             MinHeight="32" 
             Text="{Binding Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
             VerticalContentAlignment="Center" 
@@ -40,28 +46,73 @@
         <Label 
             Grid.Row="2"
             Grid.ColumnSpan="2"
+            Content="Name" />
+        <TextBox 
+            Grid.Row="3"
+            Grid.ColumnSpan="2"
+            x:Name="tbName" 
+            ToolTip="Enter name"
+            Margin="0 0 0 10"
+            MinHeight="32"
+            Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            VerticalContentAlignment="Center"
+            KeyUp="TbName_KeyUp"/>
+
+        <Label 
+            Grid.Row="4"
+            Grid.ColumnSpan="2"
+            Content="Surname" />
+        <TextBox 
+            Grid.Row="5"
+            Grid.ColumnSpan="2" 
+            x:Name="tbSurname"
+            ToolTip="Enter surname"
+            Margin="0 0 0 10"
+            MinHeight="32"
+            Text="{Binding Surname, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            VerticalContentAlignment="Center"
+            KeyUp="TbSurname_KeyUp"/>
+
+        <Label 
+            Grid.Row="6"
+            Grid.ColumnSpan="2"
+            Content="Email" />
+        <TextBox 
+            Grid.Row="7"
+            Grid.ColumnSpan="2" 
+            x:Name="tbEmail"
+            ToolTip="Enter email"
+            Margin="0 0 0 10"
+            MinHeight="32"
+            Text="{Binding Email, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            VerticalContentAlignment="Center"
+            KeyUp="TbEmail_KeyUp"/>
+
+        <Label 
+            Grid.Row="8"
+            Grid.ColumnSpan="2"
             Content="Password" />
         <TextBox 
+            Grid.Row="9"
+            Grid.ColumnSpan="2" 
             x:Name="tbPassword" 
             ToolTip="Enter password"
             Margin="0 0 0 10"
-            Grid.Row="3"
-            Grid.ColumnSpan="2" 
             MinHeight="32"
             Text="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             VerticalContentAlignment="Center"
             KeyUp="TbPassword_KeyUp"/>
 
         <Label
+            Grid.Row="10"
             Height="32"
             VerticalAlignment="Center"
             Foreground="IndianRed" 
-            Grid.Row="4"
             Grid.Column="0"
             Content="{Binding ErrorText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <StackPanel 
-            Grid.Row="4" 
+            Grid.Row="11" 
             Grid.Column="1"
             Orientation="Horizontal" 
             HorizontalAlignment="Right">
@@ -70,8 +121,8 @@
                 Content="Cancel"
                 Click="Cancel_Click"/>
             <Button 
-                Content="Login"
-                Click="Login_Click"/>
+                Content="Register"
+                Click="Register_Click"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/YouTravel/Shared/Register.xaml
+++ b/YouTravel/Shared/Register.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:YouTravel.Shared"
         mc:Ignorable="d"
-        Title="Register" Height="450" Width="400"
+        Title="Register" Height="550" Width="400"
         ResizeMode="NoResize"
         Style="{StaticResource WinDark}"
         KeyUp="Window_KeyUp">
@@ -26,14 +26,19 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
+        <Label
+            Grid.Row="0"
+            Content="Register"
+            FontSize="28"/>
 
         <Label 
-            Grid.Row="0"
+            Grid.Row="1"
             Grid.ColumnSpan="2" 
-            Content="Username" />
+            Content="Username*" />
         <TextBox
-            Grid.Row="1" 
+            Grid.Row="2" 
             Grid.ColumnSpan="2"
             x:Name="tbUsername" 
             ToolTip="Enter username"
@@ -44,41 +49,11 @@
             KeyUp="TbUsername_KeyUp"/>
 
         <Label 
-            Grid.Row="2"
-            Grid.ColumnSpan="2"
-            Content="Name" />
-        <TextBox 
             Grid.Row="3"
             Grid.ColumnSpan="2"
-            x:Name="tbName" 
-            ToolTip="Enter name"
-            Margin="0 0 0 10"
-            MinHeight="32"
-            Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-            VerticalContentAlignment="Center"
-            KeyUp="TbName_KeyUp"/>
-
-        <Label 
+            Content="Email*" />
+        <TextBox 
             Grid.Row="4"
-            Grid.ColumnSpan="2"
-            Content="Surname" />
-        <TextBox 
-            Grid.Row="5"
-            Grid.ColumnSpan="2" 
-            x:Name="tbSurname"
-            ToolTip="Enter surname"
-            Margin="0 0 0 10"
-            MinHeight="32"
-            Text="{Binding Surname, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-            VerticalContentAlignment="Center"
-            KeyUp="TbSurname_KeyUp"/>
-
-        <Label 
-            Grid.Row="6"
-            Grid.ColumnSpan="2"
-            Content="Email" />
-        <TextBox 
-            Grid.Row="7"
             Grid.ColumnSpan="2" 
             x:Name="tbEmail"
             ToolTip="Enter email"
@@ -89,22 +64,52 @@
             KeyUp="TbEmail_KeyUp"/>
 
         <Label 
-            Grid.Row="8"
+            Grid.Row="5"
             Grid.ColumnSpan="2"
-            Content="Password" />
+            Content="Password*" />
         <TextBox 
-            Grid.Row="9"
+            Grid.Row="6"
             Grid.ColumnSpan="2" 
             x:Name="tbPassword" 
             ToolTip="Enter password"
-            Margin="0 0 0 10"
+            Margin="0 0 0 25"
             MinHeight="32"
             Text="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             VerticalContentAlignment="Center"
             KeyUp="TbPassword_KeyUp"/>
 
-        <Label
+        <Label 
+            Grid.Row="7"
+            Grid.ColumnSpan="2"
+            Content="Name*" />
+        <TextBox 
+            Grid.Row="8"
+            Grid.ColumnSpan="2"
+            x:Name="tbName" 
+            ToolTip="Enter name"
+            Margin="0 0 0 10"
+            MinHeight="32"
+            Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            VerticalContentAlignment="Center"
+            KeyUp="TbName_KeyUp"/>
+
+        <Label 
+            Grid.Row="9"
+            Grid.ColumnSpan="2"
+            Content="Surname*" />
+        <TextBox 
             Grid.Row="10"
+            Grid.ColumnSpan="2" 
+            x:Name="tbSurname"
+            ToolTip="Enter surname"
+            Margin="0 0 0 20"
+            MinHeight="32"
+            Text="{Binding Surname, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            VerticalContentAlignment="Center"
+            KeyUp="TbSurname_KeyUp"/>
+
+        <Label
+            Grid.Row="11"
             Height="32"
             VerticalAlignment="Center"
             Foreground="IndianRed" 
@@ -112,16 +117,18 @@
             Content="{Binding ErrorText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <StackPanel 
-            Grid.Row="11" 
-            Grid.Column="1"
+            Grid.Row="12" 
+            Grid.ColumnSpan="2"
             Orientation="Horizontal" 
-            HorizontalAlignment="Right">
+            HorizontalAlignment="Center">
             <Button 
                 Margin="0 0 10 0" 
+                MinWidth="80"
                 Content="Cancel"
                 Click="Cancel_Click"/>
             <Button 
                 Content="Register"
+                MinWidth="80"
                 Click="Register_Click"/>
         </StackPanel>
     </Grid>

--- a/YouTravel/Shared/Register.xaml
+++ b/YouTravel/Shared/Register.xaml
@@ -6,6 +6,7 @@
         xmlns:local="clr-namespace:YouTravel.Shared"
         xmlns:util="clr-namespace:YouTravel.Util"
         mc:Ignorable="d"
+        WindowStartupLocation="CenterOwner"
         Title="Register" Height="550" Width="400"
         ResizeMode="NoResize"
         Style="{StaticResource WinDark}"

--- a/YouTravel/Shared/Register.xaml
+++ b/YouTravel/Shared/Register.xaml
@@ -171,11 +171,13 @@
             <Button 
                 Content="Register"
                 Margin="0 0 10 0" 
+                MinHeight="32"
                 MinWidth="80"
                 IsEnabled="{Binding ValidForm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 Click="Register_Click"/>
             <Button 
                 MinWidth="80"
+                MinHeight="32"
                 Content="Cancel"
                 Click="Cancel_Click"/>
         </StackPanel>

--- a/YouTravel/Shared/Register.xaml
+++ b/YouTravel/Shared/Register.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:YouTravel.Shared"
+        xmlns:util="clr-namespace:YouTravel.Util"
         mc:Ignorable="d"
         Title="Register" Height="550" Width="400"
         ResizeMode="NoResize"
@@ -28,15 +29,28 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
+        <Grid.Resources>
+            <util:BoolErrorToVisibilityConverter x:Key="BoolErrorToVisibilityConverter"/>
+        </Grid.Resources>
         <Label
             Grid.Row="0"
             Content="Register"
             FontSize="28"/>
 
-        <Label 
+        <Label
             Grid.Row="1"
-            Grid.ColumnSpan="2" 
+            Grid.Column="0" 
             Content="Username*" />
+        <Label
+            Grid.Row="1"
+            Grid.Column="1" 
+            HorizontalAlignment="Right"
+            Foreground="IndianRed"
+            Content="Cannot be empty"
+            Visibility="{Binding UsernameError,
+            Mode=TwoWay,
+            UpdateSourceTrigger=PropertyChanged,
+            Converter={StaticResource BoolErrorToVisibilityConverter}}"/>
         <TextBox
             Grid.Row="2" 
             Grid.ColumnSpan="2"
@@ -50,8 +64,18 @@
 
         <Label 
             Grid.Row="3"
-            Grid.ColumnSpan="2"
+            Grid.Column="0"
             Content="Email*" />
+        <Label
+            Grid.Row="3"
+            Grid.Column="1" 
+            HorizontalAlignment="Right"
+            Foreground="IndianRed"
+            Content="Cannot be empty"
+            Visibility="{Binding EmailError,
+            Mode=TwoWay,
+            UpdateSourceTrigger=PropertyChanged,
+            Converter={StaticResource BoolErrorToVisibilityConverter}}"/>
         <TextBox 
             Grid.Row="4"
             Grid.ColumnSpan="2" 
@@ -65,8 +89,18 @@
 
         <Label 
             Grid.Row="5"
-            Grid.ColumnSpan="2"
+            Grid.Column="0"
             Content="Password*" />
+        <Label
+            Grid.Row="5"
+            Grid.Column="1" 
+            HorizontalAlignment="Right"
+            Foreground="IndianRed"
+            Content="Cannot be empty"
+            Visibility="{Binding PasswordError,
+            Mode=TwoWay,
+            UpdateSourceTrigger=PropertyChanged,
+            Converter={StaticResource BoolErrorToVisibilityConverter}}"/>
         <TextBox 
             Grid.Row="6"
             Grid.ColumnSpan="2" 
@@ -80,8 +114,18 @@
 
         <Label 
             Grid.Row="7"
-            Grid.ColumnSpan="2"
+            Grid.Column="0"
             Content="Name*" />
+        <Label
+            Grid.Row="7"
+            Grid.Column="1" 
+            HorizontalAlignment="Right"
+            Foreground="IndianRed"
+            Content="Cannot be empty"
+            Visibility="{Binding NameError,
+            Mode=TwoWay,
+            UpdateSourceTrigger=PropertyChanged,
+            Converter={StaticResource BoolErrorToVisibilityConverter}}"/>
         <TextBox 
             Grid.Row="8"
             Grid.ColumnSpan="2"
@@ -95,8 +139,18 @@
 
         <Label 
             Grid.Row="9"
-            Grid.ColumnSpan="2"
+            Grid.Column="0"
             Content="Surname*" />
+        <Label
+            Grid.Row="9"
+            Grid.Column="1" 
+            HorizontalAlignment="Right"
+            Foreground="IndianRed"
+            Content="Cannot be empty"
+            Visibility="{Binding SurnameError,
+            Mode=TwoWay,
+            UpdateSourceTrigger=PropertyChanged,
+            Converter={StaticResource BoolErrorToVisibilityConverter}}"/>
         <TextBox 
             Grid.Row="10"
             Grid.ColumnSpan="2" 
@@ -108,16 +162,8 @@
             VerticalContentAlignment="Center"
             KeyUp="TbSurname_KeyUp"/>
 
-        <Label
-            Grid.Row="11"
-            Height="32"
-            VerticalAlignment="Center"
-            Foreground="IndianRed" 
-            Grid.Column="0"
-            Content="{Binding ErrorText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-
         <StackPanel 
-            Grid.Row="12" 
+            Grid.Row="11" 
             Grid.ColumnSpan="2"
             Orientation="Horizontal" 
             HorizontalAlignment="Center">
@@ -129,6 +175,7 @@
             <Button 
                 Content="Register"
                 MinWidth="80"
+                IsEnabled="{Binding ValidForm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 Click="Register_Click"/>
         </StackPanel>
     </Grid>

--- a/YouTravel/Shared/Register.xaml
+++ b/YouTravel/Shared/Register.xaml
@@ -101,14 +101,14 @@
             Mode=TwoWay,
             UpdateSourceTrigger=PropertyChanged,
             Converter={StaticResource BoolErrorToVisibilityConverter}}"/>
-        <TextBox 
+        <PasswordBox 
             Grid.Row="6"
             Grid.ColumnSpan="2" 
             x:Name="tbPassword" 
             ToolTip="Enter password"
             Margin="0 0 0 25"
             MinHeight="32"
-            Text="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            PasswordChanged="TbPassword_PasswordChanged"
             VerticalContentAlignment="Center"
             KeyUp="TbPassword_KeyUp"/>
 
@@ -168,15 +168,15 @@
             Orientation="Horizontal" 
             HorizontalAlignment="Center">
             <Button 
-                Margin="0 0 10 0" 
-                MinWidth="80"
-                Content="Cancel"
-                Click="Cancel_Click"/>
-            <Button 
                 Content="Register"
                 MinWidth="80"
                 IsEnabled="{Binding ValidForm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 Click="Register_Click"/>
+            <Button 
+                Margin="0 0 10 0" 
+                MinWidth="80"
+                Content="Cancel"
+                Click="Cancel_Click"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/YouTravel/Shared/Register.xaml
+++ b/YouTravel/Shared/Register.xaml
@@ -170,11 +170,11 @@
             HorizontalAlignment="Center">
             <Button 
                 Content="Register"
+                Margin="0 0 10 0" 
                 MinWidth="80"
                 IsEnabled="{Binding ValidForm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 Click="Register_Click"/>
             <Button 
-                Margin="0 0 10 0" 
                 MinWidth="80"
                 Content="Cancel"
                 Click="Cancel_Click"/>

--- a/YouTravel/Shared/Register.xaml.cs
+++ b/YouTravel/Shared/Register.xaml.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Reflection.Metadata;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using YouTravel.Model;
 
@@ -195,6 +196,11 @@ namespace YouTravel.Shared
             {
                 Close();
             }
+        }
+
+        private void TbPassword_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            Password = ((PasswordBox)sender).Password;
         }
     }
 }

--- a/YouTravel/Shared/Register.xaml.cs
+++ b/YouTravel/Shared/Register.xaml.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Input;
+using YouTravel.Model;
+
+namespace YouTravel.Shared
+{
+    /// <summary>
+    /// Interaction logic for Register.xaml
+    /// </summary>
+    public partial class Register : Window, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+        void DoPropertyChanged(string prop) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+
+        private string _username = "";
+        public string Username
+        {
+            get { return _username; }
+            set { _username = value; DoPropertyChanged(nameof(Username)); }
+        }
+
+        private string _name = "";
+        // Can't use Name since it hides an inherited member
+        public string UName
+        {
+            get { return _name; }
+            set { _name = value; DoPropertyChanged(nameof(UName)); }
+        }
+
+        private string _surname = "";
+        public string Surname
+        {
+            get { return _surname; }
+            set { _surname = value; DoPropertyChanged(nameof(Surname)); }
+        }
+
+        private string _email = "";
+        public string Email
+        {
+            get { return _email; }
+            set { _email = value; DoPropertyChanged(nameof(Email)); }
+        }
+
+        private string _password = "";
+        public string Password
+        {
+            get { return _password; }
+            set { _password = value; DoPropertyChanged(nameof(Password)); }
+        }
+
+        private string? _errorText;
+        public string? ErrorText
+        {
+            get { return _errorText; }
+            set { _errorText = value; DoPropertyChanged(nameof(ErrorText)); }
+        }
+
+        public new User? DialogResult { get; set; }
+
+        public Register()
+        {
+            InitializeComponent();
+            DataContext = this;
+
+            // TODO: Is this necessary if we call the window with ShowDialog() instead of Show()?
+            Owner = Application.Current.MainWindow;
+            tbUsername.Focus();
+        }
+
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void Register_Click(object sender, RoutedEventArgs e)
+        {
+            AttemptRegister();
+        }
+
+        private void AttemptRegister()
+        {
+            using var db = new TravelContext();
+            var user = new User()
+            {
+                Username = Username,
+                Name = UName,
+                Surname = Surname,
+                Email = Email,
+                Password = Password,
+            };
+            db.Users.Add(user);
+            db.SaveChanges();
+            DialogResult = user;
+            Close();
+        }
+
+        private void TbUsername_KeyUp(object sender, KeyEventArgs e)
+        {
+            KeyUpHelper(e.Key);
+        }
+
+        private void TbName_KeyUp(object sender, KeyEventArgs e)
+        {
+            KeyUpHelper(e.Key);
+        }
+
+        private void TbSurname_KeyUp(object sender, KeyEventArgs e)
+        {
+            KeyUpHelper(e.Key);
+        }
+
+        private void TbEmail_KeyUp(object sender, KeyEventArgs e)
+        {
+            KeyUpHelper(e.Key);
+        }
+
+        private void TbPassword_KeyUp(object sender, KeyEventArgs e)
+        {
+            KeyUpHelper(e.Key);
+        }
+
+        private void KeyUpHelper(Key key)
+        {
+            if (key == Key.Enter)
+            {
+                AttemptRegister();
+            }
+            else
+            {
+                ErrorText = null;
+            }
+        }
+
+        private void Window_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
+            }
+        }
+    }
+}

--- a/YouTravel/Shared/Register.xaml.cs
+++ b/YouTravel/Shared/Register.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Reflection.Metadata;
 using System.Windows;
 using System.Windows.Input;
 using YouTravel.Model;
@@ -50,14 +51,49 @@ namespace YouTravel.Shared
             set { _password = value; DoPropertyChanged(nameof(Password)); }
         }
 
-        private string? _errorText;
-        public string? ErrorText
+        private bool _usernameError = true;
+        public bool UsernameError
         {
-            get { return _errorText; }
-            set { _errorText = value; DoPropertyChanged(nameof(ErrorText)); }
+            get { return _usernameError; }
+            set { _usernameError = value; ValidateForm(); DoPropertyChanged(nameof(UsernameError)); }
+        }
+
+        private bool _nameError = true;
+        public bool NameError
+        {
+            get { return _nameError; }
+            set { _nameError = value; ValidateForm(); DoPropertyChanged(nameof(NameError)); }
+        }
+
+        private bool _surnameError = true;
+        public bool SurnameError
+        {
+            get { return _surnameError; }
+            set { _surnameError = value; ValidateForm(); DoPropertyChanged(nameof(SurnameError)); }
+        }
+
+        private bool _emailError = true;
+        public bool EmailError
+        {
+            get { return _emailError; }
+            set { _emailError = value; ValidateForm(); DoPropertyChanged(nameof(EmailError)); }
+        }
+
+        private bool _passwordError = true;
+        public bool PasswordError
+        {
+            get { return _passwordError; }
+            set { _passwordError = value; ValidateForm(); DoPropertyChanged(nameof(PasswordError)); }
         }
 
         public new User? DialogResult { get; set; }
+
+        private bool _validForm = false;
+        public bool ValidForm
+        {
+            get { return _validForm; }
+            set { _validForm = value; DoPropertyChanged(nameof(ValidForm)); }
+        }
 
         public Register()
         {
@@ -67,6 +103,11 @@ namespace YouTravel.Shared
             // TODO: Is this necessary if we call the window with ShowDialog() instead of Show()?
             Owner = Application.Current.MainWindow;
             tbUsername.Focus();
+        }
+
+        private void ValidateForm()
+        {
+            ValidForm = !(UsernameError || EmailError || PasswordError || NameError || SurnameError);
         }
 
 
@@ -82,6 +123,7 @@ namespace YouTravel.Shared
 
         private void AttemptRegister()
         {
+            if (!ValidForm) return;
             using var db = new TravelContext();
             var user = new User()
             {
@@ -99,39 +141,52 @@ namespace YouTravel.Shared
 
         private void TbUsername_KeyUp(object sender, KeyEventArgs e)
         {
-            KeyUpHelper(e.Key);
+            if (e.Key == Key.Enter)
+            {
+                AttemptRegister();
+            }
+            UsernameError = IsInvalidField(Username);
         }
 
         private void TbName_KeyUp(object sender, KeyEventArgs e)
         {
-            KeyUpHelper(e.Key);
+            if (e.Key == Key.Enter)
+            {
+                AttemptRegister();
+            }
+            NameError = IsInvalidField(Name);
         }
 
         private void TbSurname_KeyUp(object sender, KeyEventArgs e)
         {
-            KeyUpHelper(e.Key);
+            if (e.Key == Key.Enter)
+            {
+                AttemptRegister();
+            }
+            SurnameError = IsInvalidField(Surname);
         }
 
         private void TbEmail_KeyUp(object sender, KeyEventArgs e)
         {
-            KeyUpHelper(e.Key);
+            if (e.Key == Key.Enter)
+            {
+                AttemptRegister();
+            }
+            EmailError = IsInvalidField(Email);
         }
 
         private void TbPassword_KeyUp(object sender, KeyEventArgs e)
         {
-            KeyUpHelper(e.Key);
-        }
-
-        private void KeyUpHelper(Key key)
-        {
-            if (key == Key.Enter)
+            if (e.Key == Key.Enter)
             {
                 AttemptRegister();
             }
-            else
-            {
-                ErrorText = null;
-            }
+            PasswordError = IsInvalidField(Password);
+        }
+
+        private static bool IsInvalidField(string field)
+        {
+            return field == "";
         }
 
         private void Window_KeyUp(object sender, KeyEventArgs e)

--- a/YouTravel/Util/Converters.cs
+++ b/YouTravel/Util/Converters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Windows;
 using System.Windows.Data;
 using YouTravel.Model;
 
@@ -51,6 +52,19 @@ namespace YouTravel.Util
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             return (Place)value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
+
+    public class BoolErrorToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (bool)value ? Visibility.Visible : Visibility.Collapsed;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/YouTravel/Util/UserConfig.cs
+++ b/YouTravel/Util/UserConfig.cs
@@ -11,6 +11,7 @@ namespace YouTravel.Util
         public event PropertyChangedEventHandler? PropertyChanged;
         void DoPropertyChanged(string prop) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
 
+        private string _LoggedInUserUsername = "";
         private bool _ToolbarVisible = true;
         private bool _ToolbarNav_Visible = true;
         private bool _ToolbarArrangement_Visible = true;
@@ -18,6 +19,7 @@ namespace YouTravel.Util
         private double _StartLocation_Lat = 45.2;
         private double _StartLocation_Long = 19;
 
+        public string LoggedInUserUsername { get { return _LoggedInUserUsername; } set { _LoggedInUserUsername = value; DoPropertyChanged("LoggedInUserUsername"); } }
         public bool ToolbarVisible { get { return _ToolbarVisible; } set { _ToolbarVisible = value; DoPropertyChanged("ToolbarVisible"); } }
         public bool ToolbarNav_Visible { get { return _ToolbarNav_Visible; } set { _ToolbarNav_Visible = value; DoPropertyChanged("ToolbarNav_Visible"); } }
         public bool ToolbarArrangement_Visible { get { return _ToolbarArrangement_Visible; } set { _ToolbarArrangement_Visible = value; DoPropertyChanged("ToolbarArrangement_Visible"); } }
@@ -26,10 +28,13 @@ namespace YouTravel.Util
         public double StartLocation_Long { get { return _StartLocation_Long; } set { _StartLocation_Long = value; DoPropertyChanged("StartLocation_Long"); } }
 
         private static readonly UserConfig _instance = new();
-        private UserConfig() { }
+        private UserConfig()
+        {
+            LoadConfig();
+        }
         public static UserConfig Instance { get { return _instance; } }
 
-        public void LoadToolbarConfig()
+        private void LoadConfig()
         {
             var lines = File.ReadAllLines("./Data/UserConfig.preferences").ToList();
 
@@ -39,6 +44,10 @@ namespace YouTravel.Util
                 var key = tokens[0];
                 var value = tokens[1];
 
+                if (key == "LoggedInUserUsername")
+                {
+                    LoggedInUserUsername = value;
+                }
                 if (key == "ToolbarVisible")
                 {
                     ToolbarVisible = bool.Parse(value.ToString());
@@ -70,6 +79,7 @@ namespace YouTravel.Util
         {
             string s = "";
 
+            s += $"LoggedInUserUsername={LoggedInUserUsername}\n";
             s += $"ToolbarVisible={ToolbarVisible}\n";
             s += $"ToolbarNav_Visible={ToolbarNav_Visible}\n";
             s += $"ToolbarArrangement_Visible={ToolbarArrangement_Visible}\n";

--- a/YouTravel/Util/YouTravelContext.cs
+++ b/YouTravel/Util/YouTravelContext.cs
@@ -24,5 +24,19 @@ namespace YouTravel.Util
         {
             User = null;
         }
+
+        public static bool Login(string username, string password)
+        {
+            using var db = new TravelContext();
+            try
+            {
+                User = db.Users.Single(u => u.Username == username && u.Password == password);
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+        }
     }
 }

--- a/YouTravel/Util/YouTravelContext.cs
+++ b/YouTravel/Util/YouTravelContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using YouTravel.Model;
 
@@ -25,18 +26,21 @@ namespace YouTravel.Util
             User = null;
         }
 
-        public static bool Login(string username, string password)
+        public static void Login(string username, string password)
         {
             using var db = new TravelContext();
             try
             {
                 User = db.Users.Single(u => u.Username == username && u.Password == password);
-                return true;
             }
             catch (InvalidOperationException)
             {
-                return false;
+                throw new LoginFailedException();
             }
         }
+    }
+
+    public class LoginFailedException : Exception
+    {
     }
 }

--- a/YouTravel/Util/YouTravelContext.cs
+++ b/YouTravel/Util/YouTravelContext.cs
@@ -7,7 +7,7 @@ namespace YouTravel.Util
     public static class YouTravelContext
     {
         public static UserConfig UserConfig { get; private set; }
-        public static User? User { get; set; }
+        public static User? User { get; private set; }
 
         static YouTravelContext()
         {
@@ -18,6 +18,11 @@ namespace YouTravel.Util
                 User = db.Users.Single(u => u.Username == UserConfig.LoggedInUserUsername);
             }
             catch (InvalidOperationException) { }
+        }
+
+        public static void Logout()
+        {
+            User = null;
         }
     }
 }

--- a/YouTravel/Util/YouTravelContext.cs
+++ b/YouTravel/Util/YouTravelContext.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using YouTravel.Model;
+
+namespace YouTravel.Util
+{
+    public static class YouTravelContext
+    {
+        public static UserConfig UserConfig { get; private set; }
+        public static User? User { get; set; }
+
+        static YouTravelContext()
+        {
+            UserConfig = UserConfig.Instance;
+            using var db = new TravelContext();
+            try
+            {
+                User = db.Users.Single(u => u.Username == UserConfig.LoggedInUserUsername);
+            }
+            catch (InvalidOperationException) { }
+        }
+    }
+}


### PR DESCRIPTION
### Todo:
- [x] QoL
- [ ] Find a way to empty _all_ entries from back history

Note that logging in/out also updates `AgentMainWindow`'s `myFrame`, it's just not visually apparent. Once we add some client specific windows we can navigate to that instead (or if we make `ArrangementList` user agnostic).